### PR TITLE
Feature/indicator levels

### DIFF
--- a/resources/staging_config.edn
+++ b/resources/staging_config.edn
@@ -1,170 +1,237 @@
 {:datasets [{:indicator-id "23"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :lower_ci :upper_ci :breakdown
+                                 :level_description :level]
              :conditions [{:field :level_description :values #{"England"}}]
              :resource-id "fe5836ec-4862-489c-a4ec-db7bf91de9cf"}
             {:indicator-id "45"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :lower_ci :upper_ci]
              :conditions [{:field :level_description :values #{"England"}}]
              :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"}
             {:indicator-id "46"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :lower_ci :upper_ci]
              :conditions [{:field :level_description :values #{"England"}}]
              :resource-id "9963285f-752f-4dbb-8c02-07868ae52905"}
             {:indicator-id "47"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :lower_ci :upper_ci]
              :conditions [{:field :level_description :values #{"England"}}]
              :resource-id "02d26183-1a69-4540-8254-00216622124e"}
             {:indicator-id "48"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :lower_ci :upper_ci]
              :conditions [{:field :level_description :values #{"England"}}]
              :resource-id "db911491-ac1b-4148-ab8c-a2e8596d5257"}
             {:indicator-id "52"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "81c8e579-cdeb-401e-bf1a-2e3bde98fc39"}
             {:indicator-id "56"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :breakdown :values #{"England"}}]
              :resource-id "eb192498-8c9c-4746-a40a-a098dff69e46"}
             {:indicator-id "58"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "2102f836-072a-42a6-b4ca-ac6aa2f96562"}
             {:indicator-id "22"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "2b10e7b4-c799-44f9-81d6-3a42f4260893"}
             {:indicator-id "24"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "8b2dbabb-9b0a-4ea6-b357-74200ae4f311"}
             {:indicator-id "27"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "e2386960-b9e1-4d9f-ba8b-6d79c5c62d94"}
             {:indicator-id "28"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "bf9fff22-599e-4d58-8b78-961bc6773d62"}
             {:indicator-id "43"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "e1ec7ee1-d387-45e3-a0dd-3c8e3162e0e0"}
+            {:indicator-id "65"
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
+             :conditions [{:field :level :values #{"England"}}]
+             :resource-id "e39649c2-e4dd-49b3-bb9d-ae7d7b69bd2d"}
+            {:indicator-id "66"
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
+             :conditions [{:field :level :values #{"England"}}]
+             :resource-id "5c932116-a89c-4efc-9db9-f4b36e812ef7"}
             {:indicator-id "44"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "f581825b-cf3e-4f5d-a358-190dcc3f8a0e"}
             {:indicator-id "61"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "f581825b-cf3e-4f5d-a358-190dcc3f8a0e"}
             {:indicator-id "62"
-             :fields-to-extract [:indicator_value_rate :year :period_of_coverage]
+             :fields-to-extract [:indicator_value_rate :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "aaa57c54-c747-4eb8-aa9e-f3da798372f3"}
             {:indicator-id "54"
-             :fields-to-extract [:indicator_value :year :period_of_coverage]
+             :fields-to-extract [:indicator_value :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :level :values #{"England"}}]
              :resource-id "3cb3fc90-3944-455a-97f0-50c9680184c7"}
             {:indicator-id "33"
-             :fields-to-extract [:average_health_gain :year :period_of_coverage]
+             :fields-to-extract [:average_health_gain :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :procedure :values #{"Hip replacement"}}
                           {:field :breakdown :values #{"England"}}]
              :resource-id "df681d82-19f0-4584-8cc2-47cecad664ad"}
             {:indicator-id "34"
-             :fields-to-extract [:average_health_gain :year :period_of_coverage]
+             :fields-to-extract [:average_health_gain :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :procedure :values #{"Knee replacement"}}
                           {:field :breakdown :values #{"England"}}]
              :resource-id "df681d82-19f0-4584-8cc2-47cecad664ad"}
             {:indicator-id "35"
-             :fields-to-extract [:average_health_gain :year :period_of_coverage]
+             :fields-to-extract [:average_health_gain :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :procedure :values #{"Groin hernia"}}
                           {:field :breakdown :values #{"England"}}]
              :resource-id "df681d82-19f0-4584-8cc2-47cecad664ad"}
             {:indicator-id "36"
-             :fields-to-extract [:average_health_gain :year :period_of_coverage]
+             :fields-to-extract [:average_health_gain :year :period_of_coverage :breakdown :level :level_description
+                                 :upper_ci :lower_ci]
              :conditions [{:field :procedure :values #{"Varicose vein"}}
                           {:field :breakdown :values #{"England"}}]
              :resource-id "df681d82-19f0-4584-8cc2-47cecad664ad"}]
  :internal-calculations {:ethnicity [{:indicator-id "213"
                                       :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
-                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage]
+                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage
+                                                                       :breakdown :level :level_description
+                                                                       :upper_ci :lower_ci]
                                                    :conditions [{:field :level_description :values #{"Pakistani" "Indian"
                                                                                                      "Bangladeshi"
                                                                                                      "Any other Asian background"}}]}
-                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage]
+                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage
+                                                                         :breakdown :level :level_description
+                                                                         :upper_ci :lower_ci]
                                                      :conditions [{:field :level_description :values #{"Pakistani" "Indian"
                                                                                                        "Bangladeshi"
                                                                                                        "Any other Asian background"}}]}
-                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage]
+                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage
+                                                                             :breakdown :level :level_description
+                                                                             :upper_ci :lower_ci]
                                                          :conditions [{:field :level_description
                                                                        :values #{"English / Welsh / Scottish / Northern Irish / British"}}]}}
                                      {:indicator-id "214"
                                       :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
-                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage]
+                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage
+                                                                       :breakdown :level :level_description
+                                                                       :upper_ci :lower_ci]
                                                    :conditions [{:field :level_description
                                                                  :values #{"Afican" "Caribbean"
                                                                            "Any other Black / African / Caribbean background"}}]}
-                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage]
+                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage
+                                                                         :breakdown :level :level_description
+                                                                         :upper_ci :lower_ci]
                                                      :conditions [{:field :level_description
                                                                    :values #{"Afican" "Caribbean"
                                                                              "Any other Black / African / Caribbean background"}}]}
-                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage]
+                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage
+                                                                             :breakdown :level :level_description
+                                                                             :upper_ci :lower_ci]
                                                          :conditions [{:field :level_description
                                                                        :values #{"English / Welsh / Scottish / Northern Irish / British"}}]}}
                                      {:indicator-id "215"
                                       :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
-                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage]
+                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage
+                                                                       :breakdown :level :level_description
+                                                                       :upper_ci :lower_ci]
                                                    :conditions [{:field :level_description
                                                                  :values #{"Chinese" "Arab" "Any other ethnic group"}}]}
-                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage]
+                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage
+                                                                         :breakdown :level :level_description
+                                                                         :upper_ci :lower_ci]
                                                      :conditions [{:field :level_description
                                                                    :values #{"Chinese" "Arab" "Any other ethnic group"}}]}
-                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage]
+                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage
+                                                                             :breakdown :level :level_description
+                                                                             :upper_ci :lower_ci]
                                                          :conditions [{:field :level_description
                                                                        :values #{"English / Welsh / Scottish / Northern Irish / British"}}]}}
                                      {:indicator-id "216"
                                       :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
-                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage]
+                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage
+                                                                       :breakdown :level :level_description
+                                                                       :upper_ci :lower_ci]
                                                    :conditions [{:field :level_description
                                                                  :values #{"White and Black Caribbean" "White and Black African"
                                                                            "White and Asian" "Any other Mixed / multiple ethnic background"}}]}
-                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage]
+                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage
+                                                                         :breakdown :level :level_description
+                                                                         :upper_ci :lower_ci]
                                                      :conditions [{:field :level_description
                                                                    :values #{"White and Black Caribbean" "White and Black African"
                                                                              "White and Asian" "Any other Mixed / multiple ethnic background"}}]}
-                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage]
+                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage
+                                                                             :breakdown :level :level_description
+                                                                             :upper_ci :lower_ci]
                                                          :conditions [{:field :level_description
                                                                        :values #{"English / Welsh / Scottish / Northern Irish / British"}}]}}
                                      {:indicator-id "217"
                                       :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
-                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage]
+                                      :numerators {:fields-to-extract [:numerator :year :period_of_coverage
+                                                                       :breakdown :level :level_description
+                                                                       :upper_ci :lower_ci]
                                                    :conditions [{:field :level_description
                                                                  :values #{"Irish" "Gypsy or Irish Traveller"
                                                                            "Any other White background"}}]}
-                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage]
+                                      :denominators {:fields-to-extract [:denominator :year :period_of_coverage
+                                                                         :breakdown :level :level_description
+                                                                         :upper_ci :lower_ci]
                                                      :conditions [{:field :level_description
                                                                    :values #{"Irish" "Gypsy or Irish Traveller"
                                                                              "Any other White background"}}]}
-                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage]
+                                      :indicator-values {:fields-to-extract [:indicator_value :year :period_of_coverage
+                                                                             :breakdown :level :level_description
+                                                                             :upper_ci :lower_ci]
                                                          :conditions [{:field :level_description
                                                                        :values #{"English / Welsh / Scottish / Northern Irish / British"}}]}}]
                          :deprivation [{:indicator-id "212"
                                         :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
                                         :fields-to-extract [:indicator_value :year
-                                                            :period_of_coverage :level]
+                                                            :period_of_coverage :level
+                                                            :breakdown :level :level_description
+                                                            :upper_ci :lower_cil]
                                         :conditions [{:field :breakdown
                                                       :values #{"Deprivation decile"}}]}]
                          :gender [{:indicator-id "211"
                                    :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
                                    :fields-to-extract [:indicator_value :year
-                                                       :period_of_coverage :level]
+                                                       :period_of_coverage :level
+                                                       :breakdown :level :level_description
+                                                       :upper_ci :lower_ci]
                                    :conditions [{:field :breakdown
                                                  :values #{"Gender"}}]}]
                          :end-of-life-care {:indicator-id "57"
                                             :resource-id "4db8fb10-3f21-47bc-9ba8-f3cdb067d542"
                                             :fields-to-extract [:indicator_value :question_response :year
-                                                                :period_of_coverage]
+                                                                :period_of_coverage
+                                                                :breakdown :level :level_description
+                                                                :upper_ci :lower_ci]
                                             :conditions [{:field :question_response
                                                           :values #{"Outstanding"
                                                                     "Excellent"
@@ -180,4 +247,38 @@
                                       :sum-field :cdi_count
                                       :resource-id "14b766af-ebb4-4ad0-9eda-ab115699d587"}]}
  :constitution [{:resource-id "0b788e3c-260c-473d-ae63-d1b767812538"
-                 :indicator-id "132"}]}
+                 :indicator-id "132"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:within_14_days :total]}
+                {:resource-id "3ed8da4b-f64f-41f8-8810-2419de89153b"
+                 :indicator-id "133"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:within_14_days :total]}
+                {:resource-id "86f08607-b629-43ea-921e-295d7d1c2757"
+                 :indicator-id "134"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:after_31_days :total]}
+                {:resource-id "cd72e034-5e13-4f6a-8e0a-bd4984bd5867"
+                 :indicator-id "135"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:after_31_days :total]}
+                {:resource-id "79c8c4af-aa36-4d05-ac51-abc5c2d7cb03"
+                 :indicator-id "136"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:after_31_days :total]}
+                {:resource-id "6f72db7e-e997-4226-9df6-9d375b05eb4d"
+                 :indicator-id "137"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:after_31_days :total]}
+                {:resource-id "75840e5a-dd10-4390-aa3e-64dc0a15c172"
+                 :indicator-id "138"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:after_62_days :total_treated]}
+                {:resource-id "ce88b376-e119-484c-877d-58b701766701"
+                 :indicator-id "139"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:after_62_days :total_treated]}
+                {:resource-id "32b83bff-0678-400d-825d-c9c892eb038b"
+                 :indicator-id "140"
+                 :metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+                 :division-fields [:after_62_days :total_treated]}]}

--- a/src/kixi/nhs/constitution.clj
+++ b/src/kixi/nhs/constitution.clj
@@ -3,6 +3,9 @@
             [kixi.nhs.data.storage   :as storage]))
 
 (defn total
+  "Filters specific field k from
+  the data, parses numeric values
+  and sums them up."
   [k data]
   (->> data
        (map k)
@@ -10,30 +13,35 @@
                (Integer/parseInt (clojure.string/replace % #"," ""))))
        (apply +)))
 
-(defn percentage-seen-within-14-days
-  "Calculates percentage seen within 14 days.
-  Returns a map with the result, area team code,
+(defn percentage-seen-within-x-days
+  "Calculates percentage seen within/after x days.
+  Returns a map with the result, breakdown, level,
   year and period of coverage."
-  [k v data]
-  {k v
-   :year "2014/2015" :period_of_coverage "q1"
-   :value (float (/ (total :within_14_days data)
-                    (total :total data)))})
+  [[k1 k2] metadata breakdown level level-description data]
+  (merge metadata
+         {:level level
+          :breakdown breakdown
+          :value (str (transform/divide (total k1 data)
+                                        (total k2 data)))}))
 
 (defn per-team-area
   "Splits data by area team code and calculates
-  the percentage of patients seen within 14 days.
+  the percentage of patients seen within/after x days.
   Returns a sequence of maps."
-  [data]
+  [fields metadata data]
   (->> data
        (transform/split-by-key :area_team_code_1)
-       (map #(percentage-seen-within-14-days :area_team_code (:area_team_code_1 (first %)) %))))
+       (map #(percentage-seen-within-x-days fields
+                                            metadata
+                                             "Area Team Code"
+                                             (:area_team_code_1 (first %))
+                                             (:area_team (first %)) %))))
 
 (defn per-region
   "Returns total for region (England),
   sums up data for all CCGs."
-  [data]
-  (percentage-seen-within-14-days :region "England" data))
+  [fields metadata data]
+  (percentage-seen-within-x-days fields metadata "Region" "England" "England" data))
 
 (defn scrub
   "Removes empty rows from the data,
@@ -45,8 +53,9 @@
 
 (defn process-recipe [ckan-client recipe]
   (let [data           (scrub (storage/get-resource-data ckan-client (:resource-id recipe)))
-        region-data    (per-region data)
-        team-area-data (per-team-area data)]
+        fields         (:division-fields recipe)
+        region-data    (per-region fields (:metadata recipe) data)
+        team-area-data (per-team-area fields (:metadata recipe) data)]
     (->> (conj team-area-data
                region-data)
          (transform/enrich-dataset recipe))))

--- a/src/kixi/nhs/patient_experience/deprivation.clj
+++ b/src/kixi/nhs/patient_experience/deprivation.clj
@@ -94,11 +94,15 @@
   indicators with values for 5 and 1 years from the latest entry."
   [ckan-client recipe-map]
   (let [resource_id (:resource-id recipe-map)
-        data        (storage/get-resource-data ckan-client resource_id)]
-    (->> (transform/filter-dataset recipe-map data)
-         (transform/split-by-key :year)
-         (map deprivation-groups-avg)
-         (deprivation-analysis))))
+        data        (storage/get-resource-data ckan-client resource_id)
+        level       (-> data first :level)
+        breakdown   (-> data first :breakdown)]
+    (when (seq data)
+      (->> (transform/filter-dataset recipe-map data)
+           (transform/split-by-key :year)
+           (map deprivation-groups-avg)
+           (deprivation-analysis)
+           (map #(assoc % :level level :breakdown breakdown))))))
 
 (defn analysis
   "Receives a sequence of deprivation recipes.

--- a/src/kixi/nhs/patient_experience/ethnicity.clj
+++ b/src/kixi/nhs/patient_experience/ethnicity.clj
@@ -18,7 +18,7 @@
         sum2 (:sum d2)]
     {:year year :period_of_coverage period_of_coverage
      :division-result (when (and (transform/not-nil? sum1) (transform/not-nil? sum2))
-                        (float (/ (:sum d1) (:sum d2))))}))
+                        (float (/ sum1 sum2)))}))
 
 (defn subtract-indicator-value
   "Gets a map with division result and indicator value and
@@ -38,7 +38,7 @@
   [field k data]
   (->> (transform/filter-dataset field data)
        (transform/split-by-key :year)
-       (map #(transform/sum-sequence k %))))
+       (map #(transform/sum-sequence k [:numerator :denominator] %))))
 
 (defn divide-sums
   "Gets a sequence of numerator sums and denominator sums
@@ -53,6 +53,10 @@
   (->> (divide-sums numerator-sums denominator-sums)
        (clojure.set/join indicator-values)
        (map subtract-indicator-value)
+       (map #(assoc % :level (str "\""(-> numerator-sums first :level)
+                                  "\" / \""
+                                  (-> indicator-values first :level) "\"")
+                    :breakdown (-> indicator-values first :breakdown)))
        (transform/enrich-dataset {:indicator-id indicator-id})))
 
 (defn ethnicity-analysis

--- a/src/kixi/nhs/patient_experience/gender_comparison.clj
+++ b/src/kixi/nhs/patient_experience/gender_comparison.clj
@@ -25,6 +25,7 @@
        (remove #(= (:level %) "Unknown"))
        (transform/split-by-key :year)
        (map subtract-males-from-females)
+       (map #(assoc % :level "Female - Male" :breakdown "Gender"))
        (transform/enrich-dataset recipe)))
 
 (defn process-gender-analysis

--- a/test/kixi/nhs/constitution_test.clj
+++ b/test/kixi/nhs/constitution_test.clj
@@ -1,0 +1,75 @@
+(ns kixi.nhs.constitution-test
+  (:use clojure.test)
+  (:require [kixi.nhs.constitution :as c]))
+
+(deftest total-test
+  (testing "Testing calculating total for a sequence of data."
+    (is (= 20
+           (c/total :v [{:v "10"} {:b "4" :v "5"} {:b "a" :v "5"}])))
+    (is (= 15
+           (c/total :v [{:v "10"} {:b "4" :v ""} {:b "a" :v "5"}])))
+    (is (= 15
+           (c/total :v [{:v "10"} {:b "4" :v nil} {:b "a" :v "5"}])))
+    (is (= 0
+           (c/total :v [{:b "4"} {:b "a"}])))))
+
+(deftest percentage-seen-within-x-days-test
+  (testing "Testing calulation of percentage seen within x days."
+    (let [fields   [:after_62_days :total_treated]
+          metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+          data     [{:area_team "Foo"
+                     :total_treated "10"
+                     :after_62_days "2"
+                     :within_62_days "8"
+                     :area_team_code_1 "123"}
+                    {:area_team "Foo"
+                     :total_treated "10"
+                     :after_62_days "2"
+                     :within_62_days "8"
+                     :area_team_code_1 "123"}]]
+      (is (= {:value "0.2"
+              :breakdown "Area Team Code"
+              :level "123"
+              :year "2014/2015"
+              :period_of_coverage "01/04/2014 - 30/06/2014"}
+             (c/percentage-seen-within-x-days fields
+                                              metadata
+                                              "Area Team Code"
+                                              "123" "Foo"
+                                              data))))))
+
+(deftest per-team-area-test
+  (testing "Testing calculation per team area."
+    (let [fields   [:after_62_days :total_treated]
+          metadata {:year "2014/2015" :period_of_coverage "01/04/2014 - 30/06/2014"}
+          data     [{:area_team "Foo"
+                     :total_treated "10"
+                     :after_62_days "2"
+                     :within_62_days "8"
+                     :area_team_code_1 "123"}
+                    {:area_team "Foo"
+                     :total_treated "10"
+                     :after_62_days "2"
+                     :within_62_days "8"
+                     :area_team_code_1 "123"}
+                    {:area_team "Bar"
+                     :total_treated "10"
+                     :after_62_days "2"
+                     :within_62_days "8"
+                     :area_team_code_1 "222"}
+                    {:area_team "Bar"
+                     :total_treated "10"
+                     :after_62_days "2"
+                     :within_62_days "8"
+                     :area_team_code_1 "222"}]]
+      (is (= [{:value "0.2",
+                :breakdown "Area Team Code",
+                :level "123",
+                :year "2014/2015",
+               :period_of_coverage "01/04/2014 - 30/06/2014"}
+              {:value "0.2",
+               :breakdown "Area Team Code",
+               :level "222",
+               :year "2014/2015",
+               :period_of_coverage "01/04/2014 - 30/06/2014"}]
+             (c/per-team-area fields metadata data))))))

--- a/test/kixi/nhs/data/transform_test.clj
+++ b/test/kixi/nhs/data/transform_test.clj
@@ -63,15 +63,7 @@
                   :fields-to-extract [:value :year :period_of_coverage]
                   :conditions [{:field :level :values #{"England"}}]
                   :resource-id "2b10e7b4-c799-44f9-81d6-3a42f4260893"}
-                 [{:level "England", :denominator "883852.0", :breakdown "England",
-                   :question_response_rate "97.9", :_id 1, :indicator_id nil,
-                   :year "2013/14", :level_description "England", :indicator_value "85.7",
-                   :period_of_coverage "July 2013 to March 2014", :numerator "757456.1"}
-                  {:level "England", :denominator "948507.5", :breakdown "England",
-                   :question_response_rate "97.7", :_id 2, :indicator_id nil,
-                   :year "2012/13", :level_description "England", :indicator_value "86.7",
-                   :period_of_coverage "July 2012 to March 2013", :numerator "822728.3"}
-                  {:level "Wales", :denominator "1009576.2", :breakdown "England",
+                 [{:level "Wales", :denominator "1009576.2", :breakdown "England",
                    :question_response_rate "97.3", :_id 3, :indicator_id nil,
                    :year "2011/12", :level_description "England", :indicator_value "88.3",
                    :period_of_coverage "July 2011 to March 2012", :numerator "891213.9"}])))
@@ -156,25 +148,45 @@
     (is (= {:year "2012/13" :sum 50263.6 :period_of_coverage "July 2012 to March 2013"}
            (transform/sum-sequence
             :denominator
+            [:denominator]
             [{:denominator "49962.0" :period_of_coverage "July 2012 to March 2013" :year "2012/13"}
              {:denominator "301.6" :period_of_coverage "July 2012 to March 2013" :year "2012/13"}])))
     (is (= {:year "2012" :sum 15 :period_of_coverage nil}
            (transform/sum-sequence
             :denominator
+            [:denominator]
             [{:denominator "10" :period_of_coverage nil :year "2012"}
              {:denominator "5" :period_of_coverage nil :year "2012"}])))
-    (is (= {:year "2012" :sum nil :period_of_coverage nil}
+    (is (= {:year "2012" :sum nil}
            (transform/sum-sequence
             :denominator
+            [:denominator]
             [{:denominator "" :year "2012"}
              {:denominator "" :year "2012"}])))
-    (is (= {:year "2012" :sum nil :period_of_coverage nil}
+    (is (= {:year "2012" :sum nil}
            (transform/sum-sequence
             :denominator
+            [:denominator]
             [{:denominator nil :year "2012"}
              {:denominator nil :year "2012"}])))
-    (is (= {:year "2012" :sum 1 :period_of_coverage nil}
+    (is (= {:year "2012" :sum 1}
            (transform/sum-sequence
             :denominator
+            [:denominator]
             [{:denominator "1" :year "2012"}
              {:denominator nil :year "2012"}])))))
+
+(deftest divide-test
+  (testing "Testing division."
+    (is (= 5.0
+           (transform/divide 25 5)))
+    (is  (nil?
+          (transform/divide 25 0)))
+    (is (zero?
+         (transform/divide 0 1)))
+    (is (nil?
+         (transform/divide nil 1)))
+    (is (nil?
+         (transform/divide nil nil)))
+    (is (nil?
+         (transform/divide 1 nil)))))

--- a/test/kixi/nhs/patient_experience/ethnicity_test.clj
+++ b/test/kixi/nhs/patient_experience/ethnicity_test.clj
@@ -41,30 +41,50 @@
     (is (= [{:indicator_id "213"
              :value "-0.09895137"
              :year "2013/14"
-             :period_of_coverage "July 2013 to March 2014"}
+             :period_of_coverage "July 2013 to March 2014"
+             :level "\"foo\" / \"bar\""
+             :breakdown nil}
             {:indicator_id "213"
              :value "-0.10988522"
              :year "2012/13"
-             :period_of_coverage "July 2012 to March 2013"}]
+             :period_of_coverage "July 2012 to March 2013"
+             :level "\"foo\" / \"bar\""
+             :breakdown nil}]
            (ethnicity/final-dataset "213"
-                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 37801.2}
-                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum 41031.1}]
-                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 49153.2}
-                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum 53279.2}]
-                                    [{:indicator_value 86.8 :period_of_coverage "July 2013 to March 2014" :year "2013/14"}
-                                     {:indicator_value 88 :period_of_coverage "July 2012 to March 2013" :year "2012/13"}])))
+                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 37801.2
+                                      :level "foo"}
+                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum 41031.1
+                                      :level "foo"}]
+                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 49153.2
+                                      :level "foo"}
+                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum 53279.2
+                                      :level "foo"}]
+                                    [{:indicator_value 86.8 :period_of_coverage "July 2013 to March 2014" :year "2013/14"
+                                      :level "bar"}
+                                     {:indicator_value 88 :period_of_coverage "July 2012 to March 2013" :year "2012/13"
+                                      :level "bar"}])))
     (is (= [{:indicator_id "213"
              :value nil
              :year "2013/14"
-             :period_of_coverage "July 2013 to March 2014"}
+             :period_of_coverage "July 2013 to March 2014"
+             :level "\"foo\" / \"bar\""
+             :breakdown "Ethnicity"}
             {:indicator_id "213"
              :value nil
              :year "2012/13"
+             :level "\"foo\" / \"bar\""
+             :breakdown "Ethnicity"
              :period_of_coverage "July 2012 to March 2013"}]
            (ethnicity/final-dataset "213"
-                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 37801.2}
-                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum nil}]
-                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 49153.2}
-                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum 0}]
-                                    [{:indicator_value nil :period_of_coverage "July 2013 to March 2014" :year "2013/14"}
-                                     {:indicator_value nil :period_of_coverage "July 2012 to March 2013" :year "2012/13"}])))))
+                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 37801.2
+                                      :level "foo" :breakdown "Ethnicity"}
+                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum nil
+                                      :level "foo" :breakdown "Ethnicity"}]
+                                    [{:year "2013/14" :period_of_coverage "July 2013 to March 2014" :sum 49153.2
+                                      :level "foo" :breakdown "Ethnicity"}
+                                     {:year "2012/13" :period_of_coverage "July 2012 to March 2013" :sum 0
+                                      :level "foo" :breakdown "Ethnicity"}]
+                                    [{:indicator_value nil :period_of_coverage "July 2013 to March 2014" :year "2013/14"
+                                      :level "bar" :breakdown "Ethnicity"}
+                                     {:indicator_value nil :period_of_coverage "July 2012 to March 2013" :year "2012/13"
+                                      :level "bar" :breakdown "Ethnicity"}])))))

--- a/test/kixi/nhs/patient_experience/gender_comparison_test.clj
+++ b/test/kixi/nhs/patient_experience/gender_comparison_test.clj
@@ -67,8 +67,10 @@
                :indicator_value "85.6",
                :period_of_coverage "July 2012 to March 2013"}]]
     (testing "Testing gender analysis calculation."
-      (is (= [{:indicator_id "211" :year "2013/14", :period_of_coverage "July 2013 to March 2014", :value "0.7999999999999972"}
-              {:indicator_id "211" :year "2012/13", :period_of_coverage "July 2012 to March 2013", :value "1.0999999999999943"}]
+      (is (= [{:indicator_id "211" :year "2013/14", :period_of_coverage "July 2013 to March 2014", :value "0.7999999999999972"
+               :breakdown "Gender" :level "Female - Male"}
+              {:indicator_id "211" :year "2012/13", :period_of_coverage "July 2012 to March 2013", :value "1.0999999999999943"
+               :breakdown "Gender" :level "Female - Male"}]
              (gender/gender-analysis {:indicator-id "211"
                                       :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
                                       :fields-to-extract [:indicator_value :year
@@ -76,7 +78,8 @@
                                       :conditions [{:field :breakdown
                                                     :values #{"Gender"}}]}
                                      data)))
-      (is (= [{:indicator_id "211" :year "2011", :period_of_coverage "2011", :value "-5"}]
+      (is (= [{:indicator_id "211" :year "2011", :period_of_coverage "2011", :value "-5"
+               :breakdown "Gender" :level "Female - Male"}]
              (gender/gender-analysis {:indicator-id "211"
                                       :resource-id "7cb803a1-5c88-46e0-9e61-cf4c47ffadcb"
                                       :fields-to-extract [:indicator_value :year


### PR DESCRIPTION
- Change the PK of the Board Report resource to add `level` as additional key.
- Add `breakdown`, `level_description`, `upper_ci` and '`lower_ci` to the fields and update recipes
  and tests accordingly.
- Add all remaining available NHS Constitution indicators to the resource.
