### PR TITLE
Feature/add lci and uci

### DIFF
--- a/resources/prod_config.edn
+++ b/resources/prod_config.edn
@@ -28,6 +28,7 @@
                     :conditions [{:field :level_description :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :divide}
                     :resource-id "800d0b08-95f7-4a0f-abd5-8bcb2528d8b4"}
 
@@ -41,6 +42,7 @@
                     :conditions [{:field :level_description :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :divide}
                     :resource-id "5ca47971-5d9e-4b50-93f0-8a8ecc90c072"}
 
@@ -54,6 +56,7 @@
                     :conditions [{:field :level_description :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :divide}
                     :resource-id "bcdaf636-32d0-4122-9828-e01c14d95f0b"}
 
@@ -172,6 +175,7 @@
                     :conditions [{:field :level :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :divide}
                     :resource-id "c05f9627-8932-4db8-b1d6-ccb29197158d"}
 
@@ -185,6 +189,7 @@
                     :conditions [{:field :level :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :divide}
                     :resource-id "52a33b3d-d8aa-4934-b769-62f73ec67e1e"}
 
@@ -198,6 +203,7 @@
                     :conditions [{:field :level :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :none}
                     :resource-id "1fa9756c-ea6c-4bbf-9c7e-7c4928ed3772"}
 
@@ -211,6 +217,7 @@
                     :conditions [{:field :level :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :none}
                     :resource-id "01652770-ee37-4b47-b83b-f3a9627c3cd2"}
 
@@ -226,7 +233,8 @@
                                  {:field :breakdown :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
-                    :format {:percentage :none}
+                    :calculate-ci true
+		    :format {:percentage :none}
                     :resource-id "7e4d2547-e723-4269-97f6-b607a0d5875f"}
 
                    ;; Total health gain as assessed by patients for elective
@@ -241,6 +249,7 @@
                                  {:field :breakdown :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :none}
                     :resource-id "7e4d2547-e723-4269-97f6-b607a0d5875f"}
 
@@ -256,6 +265,7 @@
                                  {:field :breakdown :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :none}
                     :resource-id "7e4d2547-e723-4269-97f6-b607a0d5875f"}
 
@@ -271,6 +281,7 @@
                                  {:field :breakdown :values #{"England"}}]
                     :metadata {:sub_lens_resource_id ""
                                :lens_value "England"}
+                    :calculate-ci true
                     :format {:percentage :none}
                     :resource-id "7e4d2547-e723-4269-97f6-b607a0d5875f"}]
 
@@ -414,9 +425,12 @@
  ;; Bereaved carers' views on the quality of care in the last 3 months of life
  :end-of-life-care {:indicator-id "57"
                     :resource-id "3f6786f6-f0c7-4287-86b0-bd8cf48b5cac"
-                    :fields-to-extract [:indicator_value :question_response :year
+                    :fields-to-extract [:lower_ci :upper_ci :indicator_value
+                                        :question_response :year
                                         :period_of_coverage]
-                    :fields-to-rename {:sum :value :year :date}
+                    :fields-to-rename {:sum :value :year :date
+                                       :lower_ci :lci
+                                       :upper_ci :uci}
                     :conditions [{:field :question_response
                                   :values #{"Outstanding"
                                             "Excellent"
@@ -1484,6 +1498,7 @@
                           :metadata {:sub_lens_resource_id ""
                                      :date "01-01-2015" :period_of_coverage "2015"
                                      :lens_value "England"}
+                          :calculate-ci true
                           :format {:percentage :none}}]
 
  ;; Access to NHS Dental services
@@ -1517,4 +1532,5 @@
                                   :metadata {:sub_lens_resource_id ""
                                              :date "01-01-2015" :period_of_coverage "2015"
                                              :lens_value "England"}
+                                  :calculate-ci true
                                   :format {:percentage :none}}]}

--- a/src/kixi/nhs/board_report.clj
+++ b/src/kixi/nhs/board_report.clj
@@ -45,7 +45,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Idicator 57: Bereaved carers' views on the quality of care                           ;;
+;; Indicator 57: Bereaved carers' views on the quality of care                           ;;
 ;;              in the last 3 months of life                                            ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -75,7 +75,8 @@
   [ckan-client recipe-map resource_id]
   (->> (storage/get-resource-data ckan-client resource_id)
        (transform/filter-dataset recipe-map)
-       (transform/enrich-dataset recipe-map)))
+       (transform/enrich-dataset recipe-map)
+       (transform/calculate-lci-uci (:calculate-ci recipe-map))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Process all recipes and update board report resource                                 ;;
@@ -158,4 +159,4 @@
 ;; To insert new resource into existing dataset:
 ;; (insert-board-report-resource (:ckan-client system) "resources/prod_config.edn" "board_report")
 ;; To update existing board resource (preferable):
-;; (update-board-report-dataset (:ckan-client system) "56879843-edf2-4b66-a8e1-f27a91befb7a" "resources/prod_config.edn")
+;; (update-board-report-dataset (:ckan-client system) "68ebcbee-177f-42b5-a31e-8f706d4ebf50" "resources/prod_config.edn")

--- a/src/kixi/nhs/gp_survey.clj
+++ b/src/kixi/nhs/gp_survey.clj
@@ -39,7 +39,10 @@
   Returns a sequence of maps, where each map is
   a indicator value from a single monthly recipe."
   [ckan-client recipes]
-  (mapcat #(access-to-gp-services ckan-client %) recipes))
+  (if (some true? (map #(:calculate-ci %) recipes))
+    (->> (mapcat #(access-to-gp-services ckan-client %) recipes)
+         (transform/calculate-lci-uci true))
+    (mapcat #(access-to-gp-services ckan-client %) recipes)))
 
 (defn access-to-nhs-dental-services
   "Retrieves GP Survey results and
@@ -60,4 +63,7 @@
   Returns a sequence of maps, where each map is
   a indicator value from a single monthly recipe."
   [ckan-client recipes]
-  (mapcat #(access-to-nhs-dental-services ckan-client %) recipes))
+  (if (some true? (map #(:calculate-ci %) recipes))
+    (->> (mapcat #(access-to-nhs-dental-services ckan-client %) recipes)
+         (transform/calculate-lci-uci true))
+    (mapcat #(access-to-nhs-dental-services ckan-client %) recipes)))

--- a/test/kixi/nhs/data/transform_test.clj
+++ b/test/kixi/nhs/data/transform_test.clj
@@ -211,3 +211,67 @@
          (transform/divide nil nil)))
     (is (nil?
          (transform/divide 1 nil)))))
+
+(deftest calculate-lci-uci-test
+  (testing "Testing the calculation of CIs."
+    (is (= [{:lens_value "England", :date "2011-12-09T00:00:00",
+             :uci "0.42766399999999993", :lci "0.405", :indicator_id "33",
+             :value "0.416332", :end_date "2012-03-31", :start_date "2011-04-01",
+             :sub_lens_resource_id "", :period_of_coverage "1/4/2011 to 31/3/2012"}
+            {:lens_value "England", :date "2010-11-09T00:00:00", :indicator_id "33",
+             :value "0.405", :end_date "2011-03-31", :start_date "2010-04-01",
+             :sub_lens_resource_id "", :period_of_coverage "1/4/2010 to 31/3/2011"}
+            {:lens_value "England", :date "2009-10-09T00:00:00", :indicator_id "33",
+             :value "0.411", :end_date "2010-03-31", :start_date "2009-04-01",
+             :sub_lens_resource_id "", :period_of_coverage "1/4/2009 to 31/3/2010"}]
+           (transform/calculate-lci-uci
+            true
+            [{:end_date "2012-03-31", :start_date "2011-04-01", :value "0.416332",
+              :date "2011-12-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2011 to 31/3/2012"}
+             {:end_date "2011-03-31", :start_date "2010-04-01", :value "0.405",
+              :date "2010-11-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2010 to 31/3/2011"}
+             {:end_date "2010-03-31", :start_date "2009-04-01", :value "0.411",
+              :date "2009-10-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2009 to 31/3/2010"}])))
+    (is (= [{:end_date "2012-03-31", :start_date "2011-04-01", :value "0.416332",
+             :date "2011-12-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+             :lens_value "England", :period_of_coverage "1/4/2011 to 31/3/2012"}
+            {:end_date "2011-03-31", :start_date "2010-04-01", :value "0.405",
+             :date "2010-11-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+             :lens_value "England", :period_of_coverage "1/4/2010 to 31/3/2011"}
+            {:end_date "2010-03-31", :start_date "2009-04-01", :value "0.411",
+             :date "2009-10-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+             :lens_value "England", :period_of_coverage "1/4/2009 to 31/3/2010"}]
+           (transform/calculate-lci-uci
+            false
+            [{:end_date "2012-03-31", :start_date "2011-04-01", :value "0.416332",
+              :date "2011-12-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2011 to 31/3/2012"}
+             {:end_date "2011-03-31", :start_date "2010-04-01", :value "0.405",
+              :date "2010-11-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2010 to 31/3/2011"}
+             {:end_date "2010-03-31", :start_date "2009-04-01", :value "0.411",
+              :date "2009-10-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2009 to 31/3/2010"}])))
+    (is (= [{:end_date "2012-03-31", :start_date "2011-04-01", :value "0.416332",
+             :date "2011-12-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+             :lens_value "England", :period_of_coverage "1/4/2011 to 31/3/2012"}
+            {:end_date "2011-03-31", :start_date "2010-04-01", :value "0.405",
+             :date "2010-11-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+             :lens_value "England", :period_of_coverage "1/4/2010 to 31/3/2011"}
+            {:end_date "2010-03-31", :start_date "2009-04-01", :value "0.411",
+             :date "2009-10-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+             :lens_value "England", :period_of_coverage "1/4/2009 to 31/3/2010"}]
+           (transform/calculate-lci-uci
+            nil
+            [{:end_date "2012-03-31", :start_date "2011-04-01", :value "0.416332",
+              :date "2011-12-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2011 to 31/3/2012"}
+             {:end_date "2011-03-31", :start_date "2010-04-01", :value "0.405",
+              :date "2010-11-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2010 to 31/3/2011"}
+             {:end_date "2010-03-31", :start_date "2009-04-01", :value "0.411",
+              :date "2009-10-09T00:00:00", :indicator_id "33", :sub_lens_resource_id "",
+              :lens_value "England", :period_of_coverage "1/4/2009 to 31/3/2010"}])))))


### PR DESCRIPTION
As far as I know, CIs were needed for those indicators:
33, 34, 35, 36, 4, 44, 45, 46, 47, 54, 55, 61, 62. 
I calculated them only for the most recent dates (the one appearing in the board report).

Also 57 has CIs in ckan so I added them!
